### PR TITLE
Use vagrant user and home (travis user does not exist in vagrant box)

### DIFF
--- a/create_vagrant_box.sh
+++ b/create_vagrant_box.sh
@@ -35,6 +35,10 @@ cat <<EOF > Vagrantfile
           "version" => "latest-1.21",
           "default" => "1.9.3-p448",
           "rubies" => [{"name" => "1.9.3-p448", "arguments" => "--autolibs=2"}]
+        },
+        "travis_build_environment" => {
+          "user" => "vagrant",
+          "home" => "/home/vagrant"
         }
       }
     end


### PR DESCRIPTION
Since we are [using a vagrant box now](https://github.com/cloudfoundry/warden-test-infrastructure/commit/a14644691fbc446f2ac51652915a51b945906c30) the `travis_build_environment` also needs to be changed.
