### PR TITLE
Don't install warden into chef omnibus paths

### DIFF
--- a/ci-cookbooks/warden/recipes/default.rb
+++ b/ci-cookbooks/warden/recipes/default.rb
@@ -32,8 +32,8 @@ ruby_block "configure warden to put its rootfs outside of /tmp" do
 end
 
 execute "setup_warden" do
-  cwd "#{WARDEN_PATH}/warden"
-  command "gem install bundler && bundle install && bundle exec rake setup:bin[#{NEW_CONFIG_FILE_PATH}]"
+  # use su to trigger rvm so gems are installed with correct ruby 
+  command "su #{node.travis_build_environment.user} -l -c 'cd #{WARDEN_PATH}/warden && bundle install && rvmsudo bundle exec rake setup:bin[#{NEW_CONFIG_FILE_PATH}]'"
   action :run
 end
 


### PR DESCRIPTION
When trying to create a vagrant box I got stuck at the `setup warden` step.
The problem was that the ruby used was the omnibus ruby from the chef install. 
The solution was installing the gems via rvm under the vagrant user.
But to do this I had to use `su vagrant -l -c` because chef currently does not support [doing a login when invoking a script](https://tickets.opscode.com/browse/CHEF-2288).
An alternative would be using [rvm_shell](https://github.com/fnichol/chef-rvm#-rvm_shell).
