### PR TITLE
WARDEN_PATH owned by user, not root

### DIFF
--- a/ci-cookbooks/warden/recipes/default.rb
+++ b/ci-cookbooks/warden/recipes/default.rb
@@ -16,9 +16,14 @@ execute "remove remove all remnants of apparmor" do
   command "sudo dpkg --purge apparmor"
 end
 
+directory WARDEN_PATH do
+  owner node.travis_build_environment.user
+end
+
 git WARDEN_PATH do
   repository "git://github.com/cloudfoundry/warden.git"
   action :sync
+  user node.travis_build_environment.user
 end
 
 ruby_block "configure warden to put its rootfs outside of /tmp" do


### PR DESCRIPTION
The creation of the vagrant box creation (git clone) was failing on
permissions.  This fixes that problem.

Fixes #4
