### PR TITLE
./create_vagrant_box.sh - cannot determine group id for 'travis', does the group exist on this system?

### DIFF
--- a/create_vagrant_box.sh
+++ b/create_vagrant_box.sh
@@ -39,6 +39,7 @@ cat <<EOF > Vagrantfile
         },
         "travis_build_environment" => {
           "user" => "vagrant",
+          "group" => "vagrant",
           "home" => "/home/vagrant"
         }
       }


### PR DESCRIPTION
```
./create_vagrant_box.sh
...

[2014-02-24T10:16:38+00:00] INFO: bash[install RVM] ran successfully

================================================================================
Error executing action `create` on resource 'remote_directory[/home/vagrant/.rvm/gemsets]'
================================================================================

Chef::Exceptions::GroupIDNotFound
---------------------------------
cannot determine group id for 'travis', does the group exist on this system?

Resource Declaration:
---------------------
# In /tmp/vagrant-chef-1/chef-solo-1/cookbooks/rvm/recipes/default.rb

 52: # automatically install. We override it to include rake v0.9.2 and bundler ~> 1.1.0. MK.
 53: remote_directory "#{node.travis_build_environment.home}/.rvm/gemsets" do
 54:   files_owner node.travis_build_environment.user
 55:   files_group node.travis_build_environment.group
 56:   files_mode  0644
 57:   owner       node.travis_build_environment.user
 58:   group       node.travis_build_environment.group
 59:   mode        0755
 60: 
 61:   source      "gemsets"
 62: end
 63: 

Compiled Resource:
------------------
# Declared in /tmp/vagrant-chef-1/chef-solo-1/cookbooks/rvm/recipes/default.rb:53:in `from_file'

remote_directory("/home/vagrant/.rvm/gemsets") do
  mode 493
  retry_delay 2
  files_owner "vagrant"
  path "/home/vagrant/.rvm/gemsets"
  overwrite true
  retries 0
  recipe_name "default"
  files_backup 5
  owner "vagrant"
  files_mode 420
  source "gemsets"
  action :create
  cookbook_name :rvm
  recursive true
  group "travis"
  files_group "travis"
  provider Chef::Provider::RemoteDirectory
end

[2014-02-24T10:16:39+00:00] ERROR: Running exception handlers
[2014-02-24T10:16:39+00:00] ERROR: Exception handlers complete
[2014-02-24T10:16:39+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2014-02-24T10:16:39+00:00] FATAL: Chef::Exceptions::GroupIDNotFound: remote_directory[/home/vagrant/.rvm/gemsets] (rvm::default line 53) had an error: Chef::Exceptions::GroupIDNotFound: cannot determine group id for 'travis', does the group exist on this system?
```
